### PR TITLE
Refactor "toot" and "post" to reflect nouns and verbs

### DIFF
--- a/Localizations/ca.lproj/Localizable.strings
+++ b/Localizations/ca.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "Mencions";
 "ok" = "D'acord";
 "pending.pending-confirmation" = "El vostre compte està pendent de confirmació";
-"post" = "Publicació";
+"post.action" = "Publicació";
+"post.noun" = "Publicació";
 "preferences" = "Preferències";
 "preferences.app" = "Preferències de l'App";
 "preferences.app-icon" = "Icona de la App";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "Toots";
 "search.scope.tags" = "Etiquetes";
 "selected" = "Seleccionat";
-"send" = "Envia";
+"send.action" = "Envia";
 "share" = "Compartir";
 "share-extension-error.no-account-found" = "No s'ha trobat cap compte";
 "status.accessibility.view-author-profile" = "Veure el perfil de l'autor";
@@ -355,4 +356,5 @@
 "timelines.home" = "Inici";
 "timelines.local" = "Local";
 "timelines.federated" = "Federat";
-"toot" = "Toot";
+"toot.action" = "Toot";
+"toot.noun" = "Toot";

--- a/Localizations/cs.lproj/Localizable.strings
+++ b/Localizations/cs.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "Zmínky";
 "ok" = "Ok";
 "pending.pending-confirmation" = "Váš účet čeká na potvrzení";
-"post" = "Příspěvek";
+"post.action" = "Příspěvek";
+"post.noun" = "Příspěvek";
 "preferences" = "Nastavení";
 "preferences.app" = "Nastavení aplikace";
 "preferences.app-icon" = "Ikona aplikace";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "Tooty";
 "search.scope.tags" = "Hashtagy";
 "selected" = "Vybrané";
-"send" = "Odeslat";
+"send.action" = "Odeslat";
 "share" = "Sdílet";
 "share-extension-error.no-account-found" = "Nenalezen žádný účet";
 "status.accessibility.view-author-profile" = "Zobrazit profil autora";
@@ -355,4 +356,5 @@
 "timelines.home" = "Domů";
 "timelines.local" = "Lokální";
 "timelines.federated" = "Federované";
-"toot" = "Toot";
+"toot.action" = "Toot";
+"toot.noun" = "Toot";

--- a/Localizations/de.lproj/Localizable.strings
+++ b/Localizations/de.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "Erwähnungen";
 "ok" = "OK";
 "pending.pending-confirmation" = "Dein Account ist noch nicht bestätigt";
-"post" = "Posten";
+"post.action" = "Posten";
+"post.noun" = "Post";
 "preferences" = "Einstellungen";
 "preferences.app" = "App-Einstellungen";
 "preferences.app-icon" = "App-Icon";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "Toots";
 "search.scope.tags" = "Hashtags";
 "selected" = "Ausgewählt";
-"send" = "Senden";
+"send.action" = "Senden";
 "share" = "Teilen";
 "share-extension-error.no-account-found" = "Account nicht gefunden";
 "status.accessibility.view-author-profile" = "Profil der Autorin bwz. des Autors ansehen";
@@ -355,4 +356,5 @@
 "timelines.home" = "Startseite";
 "timelines.local" = "Lokal";
 "timelines.federated" = "Föderiert";
-"toot" = "Toot";
+"toot.action" = "Tooten";
+"toot.noun" = "Toot";

--- a/Localizations/el.lproj/Localizable.strings
+++ b/Localizations/el.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "Αναφορές";
 "ok" = "Εντάξει";
 "pending.pending-confirmation" = "Ο λογαριασμός σας εκκρεμεί επιβεβαίωση";
-"post" = "Δημοσίευση";
+"post.action" = "Δημοσίευση";
+"post.noun" = "Δημοσίευση";
 "preferences" = "Προτιμήσεις";
 "preferences.app" = "Προτιμήσεις Εφαρμογής";
 "preferences.app-icon" = "Εικονίδιο Εφαρμογής";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "Toots";
 "search.scope.tags" = "Hashtags";
 "selected" = "Επιλεγμένο";
-"send" = "Αποστολή";
+"send.action" = "Αποστολή";
 "share" = "Κοινοποίηση";
 "share-extension-error.no-account-found" = "Δε βρέθηκε λογαριασμός";
 "status.accessibility.view-author-profile" = "Προβολή προφίλ συγγραφέα";
@@ -355,4 +356,5 @@
 "timelines.home" = "Αρχική";
 "timelines.local" = "Τοπικό";
 "timelines.federated" = "Ομοσπονδιακό";
-"toot" = "Toot";
+"toot.action" = "Toot";
+"toot.noun" = "Toot";

--- a/Localizations/en.lproj/Localizable.strings
+++ b/Localizations/en.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "Mentions";
 "ok" = "OK";
 "pending.pending-confirmation" = "Your account is pending confirmation";
-"post" = "Post";
+"post.noun" = "Post";
+"post.action" = "Post";
 "preferences" = "Preferences";
 "preferences.app" = "App Preferences";
 "preferences.app-icon" = "App Icon";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "Toots";
 "search.scope.tags" = "Hashtags";
 "selected" = "Selected";
-"send" = "Send";
+"send.action" = "Send";
 "share" = "Share";
 "share-extension-error.no-account-found" = "No account found";
 "status.accessibility.view-author-profile" = "View author's profile";
@@ -355,4 +356,5 @@
 "timelines.home" = "Home";
 "timelines.local" = "Local";
 "timelines.federated" = "Federated";
-"toot" = "Toot";
+"toot.action" = "Toot";
+"toot.noun" = "Toot";

--- a/Localizations/es.lproj/Localizable.strings
+++ b/Localizations/es.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "Menciones";
 "ok" = "OK";
 "pending.pending-confirmation" = "Tu cuenta está pendiente de confirmación";
-"post" = "Publicar";
+"post.noun" = "Publicación";
+"post.action" = "Publicar";
 "preferences" = "Ajustes";
 "preferences.app" = "Ajustes de la App";
 "preferences.app-icon" = "Icono de la App";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "Toots";
 "search.scope.tags" = "Hashtags";
 "selected" = "Seleccionados";
-"send" = "Enviar";
+"send.action" = "Enviar";
 "share" = "Compartir";
 "share-extension-error.no-account-found" = "No se ha encontrado ninguna cuenta";
 "status.accessibility.view-author-profile" = "Ver perfil del autor";
@@ -355,4 +356,5 @@
 "timelines.home" = "Inicio";
 "timelines.local" = "Local";
 "timelines.federated" = "Federado";
-"toot" = "Tootear";
+"toot.action" = "Tootear";
+"toot.noun" = "Toot";

--- a/Localizations/eu.lproj/Localizable.strings
+++ b/Localizations/eu.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "Aipamenak";
 "ok" = "Ados";
 "pending.pending-confirmation" = "Zure kontua baieztapenaren zain dago";
-"post" = "Bidali";
+"post.action" = "Bidali";
+"post.noun" = "Bidali";
 "preferences" = "Hobespenak";
 "preferences.app" = "Aplikazioaren hobespenak";
 "preferences.app-icon" = "Aplikazioaren ikonoa";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "Tutak";
 "search.scope.tags" = "Traolak";
 "selected" = "Hautatuak";
-"send" = "Bidali";
+"send.action" = "Bidali";
 "share" = "Partekatu";
 "share-extension-error.no-account-found" = "Ez da konturik aurkitu";
 "status.accessibility.view-author-profile" = "Ikusi egilearen profila";
@@ -355,4 +356,5 @@
 "timelines.home" = "Hasiera";
 "timelines.local" = "Lokala";
 "timelines.federated" = "Federatua";
-"toot" = "Bidali";
+"toot.action" = "Bidali";
+"toot.noun" = "Bidali";

--- a/Localizations/fr.lproj/Localizable.strings
+++ b/Localizations/fr.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "Mentions";
 "ok" = "D'accord";
 "pending.pending-confirmation" = "Votre compte est en attente de confirmation";
-"post" = "Publier";
+"post.action" = "Publier";
+"post.noun" = "Publication";
 "preferences" = "Paramètres";
 "preferences.app" = "Paramètres de l'application";
 "preferences.app-icon" = "Icône de l’application";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "Pouets";
 "search.scope.tags" = "Mots clés";
 "selected" = "Sélectionné";
-"send" = "Envoyer";
+"send.action" = "Envoyer";
 "share" = "Partager";
 "share-extension-error.no-account-found" = "Aucun compte trouvé";
 "status.accessibility.view-author-profile" = "Voir le profil de l'auteur";
@@ -355,4 +356,5 @@
 "timelines.home" = "Global";
 "timelines.local" = "Local";
 "timelines.federated" = "Fédéré";
-"toot" = "Pouet";
+"toot.action" = "Pouet";
+"toot.noun" = "Pouet";

--- a/Localizations/gd.lproj/Localizable.strings
+++ b/Localizations/gd.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "Iomraidhean";
 "ok" = "Ceart ma-thà";
 "pending.pending-confirmation" = "Tha an cunntas agad a’ feitheamh air dearbhadh";
-"post" = "Postaich";
+"post.action" = "Postadh";
+"post.noun" = "Postaich";
 "preferences" = "Roghainnean";
 "preferences.app" = "Roghainnean na h-aplacaide";
 "preferences.app-icon" = "Ìomhaigheag na h-aplacaide";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "Postaichean";
 "search.scope.tags" = "Tagaichean hais";
 "selected" = "Air a thaghadh";
-"send" = "Cuir";
+"send.action" = "Cuir";
 "share" = "Co-roinn";
 "share-extension-error.no-account-found" = "Cha deach cunntas a lorg";
 "status.accessibility.view-author-profile" = "Seall pròifil an ùghdair";
@@ -355,4 +356,5 @@
 "timelines.home" = "Dachaigh";
 "timelines.local" = "Ionadail";
 "timelines.federated" = "Co-naisgte";
-"toot" = "Postaich";
+"toot.action" = "Postadh";
+"toot.noun" = "Postaich";

--- a/Localizations/he.lproj/Localizable.strings
+++ b/Localizations/he.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "איזכורים";
 "ok" = "אישור";
 "pending.pending-confirmation" = "החשבון שלך ממתין לאישור";
-"post" = "פרסום";
+"post.action" = "פרסום";
+"post.noun" = "פרסום";
 "preferences" = "העדפות";
 "preferences.app" = "העדפות אפליקציה";
 "preferences.app-icon" = "סמל אפליקציה";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "חיצרוצים";
 "search.scope.tags" = "תגיות";
 "selected" = "נבחר";
-"send" = "שליחה";
+"send.action" = "שליחה";
 "share" = "שיתוף";
 "share-extension-error.no-account-found" = "לא נמצא חשבון";
 "status.accessibility.view-author-profile" = "צפיה בפרופיל של כותב הפוסט";
@@ -355,4 +356,5 @@
 "timelines.home" = "בית";
 "timelines.local" = "מקומי";
 "timelines.federated" = "בפדרציה";
-"toot" = "חיצרוץ";
+"toot.action" = "חיצרוץ";
+"toot.noun" = "חיצרוץ";

--- a/Localizations/ja.lproj/Localizable.strings
+++ b/Localizations/ja.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "メンション";
 "ok" = "OK";
 "pending.pending-confirmation" = "アカウントは確認待ちです";
-"post" = "投稿";
+"post.action" = "投稿";
+"post.noun" = "投稿";
 "preferences" = "環境設定";
 "preferences.app" = "アプリ環境設定";
 "preferences.app-icon" = "アプリアイコン";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "トゥート";
 "search.scope.tags" = "ハッシュタグ";
 "selected" = "選択中";
-"send" = "送信";
+"send.action" = "送信";
 "share" = "共有";
 "share-extension-error.no-account-found" = "アカウントが見つかりません";
 "status.accessibility.view-author-profile" = "作者のプロフィールを見る";
@@ -355,4 +356,5 @@
 "timelines.home" = "ホーム";
 "timelines.local" = "ローカル";
 "timelines.federated" = "連合";
-"toot" = "トゥート";
+"toot.action" = "トゥート";
+"toot.noun" = "トゥート";

--- a/Localizations/ko.lproj/Localizable.strings
+++ b/Localizations/ko.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "멘션";
 "ok" = "확인";
 "pending.pending-confirmation" = "계정이 확인 대기 중이에요";
-"post" = "게시글";
+"post.action" = "게시글";
+"post.noun" = "게시글";
 "preferences" = "설정";
 "preferences.app" = "앱 설정";
 "preferences.app-icon" = "앱 아이콘";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "툿";
 "search.scope.tags" = "해시 태그";
 "selected" = "선택됨";
-"send" = "전송";
+"send.action" = "전송";
 "share" = "공유";
 "share-extension-error.no-account-found" = "계정을 찾지 못했어요";
 "status.accessibility.view-author-profile" = "작성자 프로필 보기";
@@ -355,4 +356,5 @@
 "timelines.home" = "홈";
 "timelines.local" = "로컬";
 "timelines.federated" = "연합";
-"toot" = "툿";
+"toot.action" = "툿";
+"toot.noun" = "툿";

--- a/Localizations/pl.lproj/Localizable.strings
+++ b/Localizations/pl.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "Wzmianki";
 "ok" = "OK";
 "pending.pending-confirmation" = "Twoje konto oczekuje na potwierdzenie";
-"post" = "Post";
+"post.noun" = "Post";
+"post.action" = "Post";
 "preferences" = "Właściwości";
 "preferences.app" = "Ustawienia aplikacji";
 "preferences.app-icon" = "Ikona aplikacji";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "Tooty";
 "search.scope.tags" = "Hashtagi";
 "selected" = "Wybrane";
-"send" = "Wyślij";
+"send.action" = "Wyślij";
 "share" = "Udostępnij";
 "share-extension-error.no-account-found" = "Nie znalazłem konta";
 "status.accessibility.view-author-profile" = "Wyświetl profil autora";
@@ -355,4 +356,5 @@
 "timelines.home" = "Domowa";
 "timelines.local" = "Lokalna";
 "timelines.federated" = "Globalna";
-"toot" = "Toot";
+"toot.action" = "Toot";
+"toot.noun" = "Toot";

--- a/Localizations/pt-BR.lproj/Localizable.strings
+++ b/Localizations/pt-BR.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "Menções";
 "ok" = "OK";
 "pending.pending-confirmation" = "Sua conta está com a confirmação pendente";
-"post" = "Post";
+"post.action" = "Post";
+"post.noun" = "Post";
 "preferences" = "Preferências";
 "preferences.app" = "Preferências do App";
 "preferences.app-icon" = "Ícone do App";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "Publicações";
 "search.scope.tags" = "Marcadores";
 "selected" = "Selecionado";
-"send" = "Enviar";
+"send.action" = "Enviar";
 "share" = "Compartilhar";
 "share-extension-error.no-account-found" = "Nenhuma conta encontrada";
 "status.accessibility.view-author-profile" = "Ver perfil do autor";
@@ -355,4 +356,5 @@
 "timelines.home" = "Início";
 "timelines.local" = "Localização";
 "timelines.federated" = "Federated";
-"toot" = "Toot";
+"toot.action" = "Toot";
+"toot.noun" = "Toot";

--- a/Localizations/ru.lproj/Localizable.strings
+++ b/Localizations/ru.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "Упоминания";
 "ok" = "ОК";
 "pending.pending-confirmation" = "Ваша учетная запись ожидает подтверждения";
-"post" = "Пост";
+"post.action" = "Пост";
+"post.noun" = "Пост";
 "preferences" = "Настройки";
 "preferences.app" = "Настройки приложения";
 "preferences.app-icon" = "Значок приложения";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "Туты";
 "search.scope.tags" = "Хештеги";
 "selected" = "Выбрано";
-"send" = "Отправить";
+"send.action" = "Отправить";
 "share" = "Поделиться";
 "share-extension-error.no-account-found" = "Аккаунт не найден";
 "status.accessibility.view-author-profile" = "Просмотр профиля автора";
@@ -355,4 +356,5 @@
 "timelines.home" = "Главная";
 "timelines.local" = "Локальная";
 "timelines.federated" = "Глобальная";
-"toot" = "Отправить";
+"toot.action" = "Отправить";
+"toot.noun" = "Отправить";

--- a/Localizations/sv.lproj/Localizable.strings
+++ b/Localizations/sv.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "Omnämnanden";
 "ok" = "OK";
 "pending.pending-confirmation" = "Ditt konto är ännu inte bekräftat";
-"post" = "Publicera";
+"post.action" = "Publicera";
+"post.noun" = "Publicera";
 "preferences" = "Inställningar";
 "preferences.app" = "Appinställningar";
 "preferences.app-icon" = "Appikon";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "Toots";
 "search.scope.tags" = "Hashtaggar";
 "selected" = "Valda";
-"send" = "Skicka";
+"send.action" = "Skicka";
 "share" = "Dela";
 "share-extension-error.no-account-found" = "Inget konto hittades";
 "status.accessibility.view-author-profile" = "Visa författarens profil";
@@ -355,4 +356,5 @@
 "timelines.home" = "Hem";
 "timelines.local" = "Lokalt";
 "timelines.federated" = "Federerat";
-"toot" = "Toot";
+"toot.action" = "Toot";
+"toot.noun" = "Toot";

--- a/Localizations/uk.lproj/Localizable.strings
+++ b/Localizations/uk.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "Згадування";
 "ok" = "Гаразд";
 "pending.pending-confirmation" = "Ваш обліковий запис очікує на підтвердження";
-"post" = "Допис";
+"post.action" = "Дописи";
+"post.noun" = "Допис";
 "preferences" = "Налаштування";
 "preferences.app" = "Налаштування додатку";
 "preferences.app-icon" = "Значок додатку";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "Гуки";
 "search.scope.tags" = "Хештеги";
 "selected" = "Вибрано";
-"send" = "Надіслати";
+"send.action" = "Надіслати";
 "share" = "Поділитися";
 "share-extension-error.no-account-found" = "Обліковий запис не знайдено";
 "status.accessibility.view-author-profile" = "Переглянути профіль автора";
@@ -355,4 +356,5 @@
 "timelines.home" = "Головна";
 "timelines.local" = "Локальна";
 "timelines.federated" = "Глобальна";
-"toot" = "Гук";
+"toot.action" = "Гуки";
+"toot.noun" = "Гук";

--- a/Localizations/zh-HK.lproj/Localizable.strings
+++ b/Localizations/zh-HK.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "提及";
 "ok" = "確定";
 "pending.pending-confirmation" = "你的帳號正在等待確認";
-"post" = "投稿";
+"post.action" = "投稿";
+"post.noun" = "投稿";
 "preferences" = "偏好設定";
 "preferences.app" = "程式偏好設定";
 "preferences.app-icon" = "應用程式圖示";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "帖文";
 "search.scope.tags" = "標籤";
 "selected" = "已選擇";
-"send" = "發送";
+"send.action" = "發送";
 "share" = "分享";
 "share-extension-error.no-account-found" = "未找到帳戶";
 "status.accessibility.view-author-profile" = "查看作者的個人檔案";
@@ -355,4 +356,5 @@
 "timelines.home" = "首頁";
 "timelines.local" = "本站";
 "timelines.federated" = "聯邦宇宙";
-"toot" = "帖文";
+"toot.action" = "帖文";
+"toot.noun" = "帖文";

--- a/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/Localizations/zh-Hans.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "提及";
 "ok" = "确定";
 "pending.pending-confirmation" = "你的帐户正在等待确认";
-"post" = "帖子";
+"post.action" = "帖子";
+"post.noun" = "帖子";
 "preferences" = "偏好设置";
 "preferences.app" = "应用偏好设置";
 "preferences.app-icon" = "应用图标";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "嘟文";
 "search.scope.tags" = "标签";
 "selected" = "已选择";
-"send" = "发送";
+"send.action" = "发送";
 "share" = "分享";
 "share-extension-error.no-account-found" = "未找到账户";
 "status.accessibility.view-author-profile" = "查看作者的个人资料";
@@ -355,4 +356,5 @@
 "timelines.home" = "主页";
 "timelines.local" = "本地";
 "timelines.federated" = "联邦宇宙";
-"toot" = "嘟文";
+"toot.action" = "嘟文";
+"toot.noun" = "嘟文";

--- a/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/Localizations/zh-Hant.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "notifications.mentions" = "提及";
 "ok" = "確定";
 "pending.pending-confirmation" = "您的帳號正在審核中";
-"post" = "嘟文";
+"post.action" = "嘟文";
+"post.noun" = "嘟文";
 "preferences" = "偏好設定";
 "preferences.app" = "偏好設定";
 "preferences.app-icon" = "應用程式圖標";
@@ -298,7 +299,7 @@
 "search.scope.statuses.toot" = "嘟文";
 "search.scope.tags" = "主題標籤";
 "selected" = "已選擇";
-"send" = "發送";
+"send.action" = "發送";
 "share" = "分享";
 "share-extension-error.no-account-found" = "未找到帳號";
 "status.accessibility.view-author-profile" = "查看作者的個人檔案";
@@ -355,4 +356,5 @@
 "timelines.home" = "首頁";
 "timelines.local" = "本站";
 "timelines.federated" = "聯邦宇宙";
-"toot" = "嘟出去";
+"toot.action" = "嘟出去";
+"toot.noun" = "嘟出去";

--- a/View Controllers/NewStatusViewController.swift
+++ b/View Controllers/NewStatusViewController.swift
@@ -484,11 +484,11 @@ private extension NewStatusViewController {
     func postActionTitle(statusWord: AppPreferences.StatusWord, visibility: Status.Visibility) -> String {
         switch (statusWord, visibility) {
         case (_, .direct):
-            return NSLocalizedString("send", comment: "")
+            return NSLocalizedString("send.action", comment: "")
         case (.toot, _):
-            return NSLocalizedString("toot", comment: "")
+            return NSLocalizedString("toot.action", comment: "")
         case (.post, _):
-            return NSLocalizedString("post", comment: "")
+            return NSLocalizedString("post.action", comment: "")
         }
     }
 }

--- a/Views/SwiftUI/PreferencesView.swift
+++ b/Views/SwiftUI/PreferencesView.swift
@@ -175,9 +175,9 @@ extension AppPreferences.StatusWord {
     var localizedStringKey: LocalizedStringKey {
         switch self {
         case .toot:
-            return "toot"
+            return "toot.noun"
         case .post:
-            return "post"
+            return "post.noun"
         }
     }
 }


### PR DESCRIPTION
In English, "toot" and "post" describe both the noun/object and the action. In other languages, there might be a difference.

### Summary

Applies upstream metabolism/metatext#129 from @vollkorntomate

### Other Information

Upstream PR indicates signed CLA.

- [x] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
- [ ] The proposed changes are limited in scope to fixing bugs, or I have discussed larger scope changes via email
