### PR TITLE
Adapt maxTootChars to new API

### DIFF
--- a/DB/Sources/DB/Extensions/Instance+Extensions.swift
+++ b/DB/Sources/DB/Extensions/Instance+Extensions.swift
@@ -36,6 +36,6 @@ private extension Instance {
                   stats: record.stats,
                   thumbnail: record.thumbnail,
                   contactAccount: contactAccount,
-                  maxTootChars: record.maxTootChars)
+                  configuration: Configuration(statuses: Configuration.Statuses(maxCharacters: record.maxTootChars)))
     }
 }

--- a/Mastodon/Sources/Mastodon/Entities/Instance.swift
+++ b/Mastodon/Sources/Mastodon/Entities/Instance.swift
@@ -13,6 +13,23 @@ public struct Instance: Codable, Hashable {
         public let domainCount: Int
     }
 
+    public struct Configuration: Codable, Hashable {
+        // swiftlint:disable:next nesting
+        public struct Statuses: Codable, Hashable {
+            public let maxCharacters: Int?
+
+            public init(maxCharacters: Int?) {
+                self.maxCharacters = maxCharacters
+            }
+        }
+
+        public let statuses: Statuses?
+
+        public init(statuses: Statuses?) {
+            self.statuses = statuses
+        }
+    }
+
     public let uri: String
     public let title: String
     public let description: String
@@ -27,7 +44,10 @@ public struct Instance: Codable, Hashable {
     public let stats: Stats
     public let thumbnail: UnicodeURL?
     public let contactAccount: Account?
-    public let maxTootChars: Int?
+    public var maxTootChars: Int? {
+        configuration?.statuses?.maxCharacters
+    }
+    public let configuration: Configuration?
 
     public init(uri: String,
                 title: String,
@@ -39,7 +59,7 @@ public struct Instance: Codable, Hashable {
                 stats: Instance.Stats,
                 thumbnail: UnicodeURL?,
                 contactAccount: Account?,
-                maxTootChars: Int?) {
+                configuration: Configuration?) {
         self.uri = uri
         self.title = title
         self.description = description
@@ -50,7 +70,7 @@ public struct Instance: Codable, Hashable {
         self.stats = stats
         self.thumbnail = thumbnail
         self.contactAccount = contactAccount
-        self.maxTootChars = maxTootChars
+        self.configuration = configuration
     }
 }
 


### PR DESCRIPTION
Use JSON key configuration.statuses.max_characters instead of max_toot_chars

### Summary

Applies upstream metabolist/metatext#141 from @vollkorntomate

### Other Information

Upstream PR indicates signed CLA.

- [x] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
- [ ] The proposed changes are limited in scope to fixing bugs, or I have discussed larger scope changes via email
