### PR TITLE
Rich text rendering in statuses

### DIFF
--- a/Feditext.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Feditext.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -54,6 +54,15 @@
           "revision": "318cca556b0489aede0cd98d8d0c7f1408ab7bd6",
           "version": "5.13.5"
         }
+      },
+      {
+        "package": "SwiftSoup",
+        "repositoryURL": "https://github.com/scinfu/SwiftSoup.git",
+        "state": {
+          "branch": null,
+          "revision": "6778575285177365cbad3e5b8a72f2a20583cfec",
+          "version": "2.4.3"
+        }
       }
     ]
   },

--- a/Mastodon/Package.swift
+++ b/Mastodon/Package.swift
@@ -13,9 +13,16 @@ let package = Package(
             name: "Mastodon",
             targets: ["Mastodon"])
     ],
-    dependencies: [],
+    dependencies: [
+        .package(
+            url: "https://github.com/scinfu/SwiftSoup.git",
+            from: "2.4.3"
+        )
+    ],
     targets: [
-        .target(name: "Mastodon"),
+        .target(
+            name: "Mastodon",
+            dependencies: ["SwiftSoup"]),
         .testTarget(
             name: "MastodonTests",
             dependencies: ["Mastodon"])

--- a/View Controllers/ExploreViewController.swift
+++ b/View Controllers/ExploreViewController.swift
@@ -59,6 +59,11 @@ final class ExploreViewController: UICollectionViewController {
 
         searchController.searchResultsUpdater = self
         searchController.searchBar.keyboardType = .twitter
+        searchController.searchBar.autocapitalizationType = .none
+        searchController.searchBar.autocorrectionType = .no
+        searchController.searchBar.smartDashesType = .no
+        searchController.searchBar.smartInsertDeleteType = .no
+        searchController.searchBar.smartQuotesType = .no
         navigationItem.searchController = searchController
 
         view.addSubview(webfingerIndicatorView)

--- a/Views/UIKit/StatusBodyView.swift
+++ b/Views/UIKit/StatusBodyView.swift
@@ -22,19 +22,15 @@ final class StatusBodyView: UIView {
         didSet {
             guard let viewModel = viewModel else { return }
 
-            let isContextParent = viewModel.configuration.isContextParent
-            let mutableContent = NSMutableAttributedString(attributedString: viewModel.content)
+            let mutableContent = Self.adaptFont(style: contentTextStyle, attributed: viewModel.content)
             let mutableSpoilerText = NSMutableAttributedString(string: viewModel.spoilerText)
-            let mutableSpoilerFont = UIFont.preferredFont(forTextStyle: isContextParent ? .title3 : .callout).bold()
+            let mutableSpoilerFont = UIFont.preferredFont(forTextStyle: contentTextStyle).bold()
             let contentFont = UIFont.preferredFont(forTextStyle: isContextParent ? .title3 : .callout)
             let contentRange = NSRange(location: 0, length: mutableContent.length)
 
             contentTextView.shouldFallthrough = !isContextParent
 
-            mutableContent.removeAttribute(.font, range: contentRange)
-            mutableContent.addAttributes(
-                [.font: contentFont, .foregroundColor: UIColor.label],
-                range: contentRange)
+            mutableContent.addAttribute(.foregroundColor, value: UIColor.label, range: contentRange)
             mutableContent.insert(emojis: viewModel.contentEmojis,
                                   view: contentTextView,
                                   identityContext: viewModel.identityContext)
@@ -348,5 +344,35 @@ private extension StatusBodyView {
         shouldHideDueToLongContent
             && !(viewModel?.shouldHideDueToSpoiler ?? false)
             && !shouldShowContent
+    }
+
+    /// Get size of body text produced by `NSAttributedString`'s HTML parser.
+    /// Default is observed height on macOS 13.
+    static let htmlBodyTextHeight: CGFloat = (NSAttributedString(html: "x")?
+        .attribute(.font, at: 0, effectiveRange: nil) as? UIFont)?
+        .pointSize
+    ?? 12.0
+
+    /// Replace HTML parser fonts with equivalent system fonts, appropriately scaled.
+    static func adaptFont(style: UIFont.TextStyle, attributed: NSAttributedString) -> NSMutableAttributedString {
+        let systemFontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: style)
+        let mutable = NSMutableAttributedString(attributedString: attributed)
+        let entireString = NSRange(location: 0, length: mutable.length)
+        mutable.enumerateAttribute(.font, in: entireString) { val, range, _ in
+            guard let font = val as? UIFont else {
+                return
+            }
+            let descriptor = font.fontDescriptor
+            let size = descriptor.pointSize / htmlBodyTextHeight * systemFontDescriptor.pointSize
+            var traits = descriptor.symbolicTraits
+            traits.remove(.classMask)
+            guard let newDescriptor = systemFontDescriptor.withSize(size).withSymbolicTraits(traits) else {
+                return
+            }
+            let newFont = UIFont(descriptor: newDescriptor, size: 0.0)
+            mutable.addAttribute(.font, value: newFont, range: range)
+        }
+        mutable.fixAttributes(in: entireString)
+        return mutable
     }
 }


### PR DESCRIPTION
### Summary

Replaces the original Metatext HTML parser with SwiftSoup, and passes through some presentation HTML elements: bold, italic, underline, etc. Should be able to render HTML produced by Markdown parsers in Glitch and other Fedi servers. Not intended to render arbitrary HTML, but uses SwiftSoup's sanitizer with a conservative safelist.

Also turns off autocorrect features for the search bar, since they make it hard to type advanced search syntax for quotes, and it helped to have that working for finding test posts quickly.
