### PR TITLE
Mac support

### DIFF
--- a/Action Extension/Action Extension.entitlements
+++ b/Action Extension/Action Extension.entitlements
@@ -6,13 +6,13 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.gotgoat.metatext</string>
+		<string>group.$(FEDITEXT_BUNDLE_ID_BASE)</string>
 	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.gotgoat.metatext</string>
+		<string>$(AppIdentifierPrefix)$(FEDITEXT_BUNDLE_ID_BASE)</string>
 	</array>
 </dict>
 </plist>

--- a/Action Extension/Info.plist
+++ b/Action Extension/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>Feditext bundle ID base</key>
+	<string>$(FEDITEXT_BUNDLE_ID_BASE)</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSExtension</key>

--- a/Feditext.xcodeproj/project.pbxproj
+++ b/Feditext.xcodeproj/project.pbxproj
@@ -330,7 +330,6 @@
 		68B0398A2934360A003570DD /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = uk; path = uk.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		75F7B3CB291F51D300FDE7C7 /* SwipeableNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableNavigationController.swift; sourceTree = "<group>"; };
 		947873BB297E0F9000CACEFE /* Identity.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Identity.xcconfig; sourceTree = "<group>"; };
-		947873BC297E1F7B00CACEFE /* Identity.xcconfig.example.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = Identity.xcconfig.example.txt; sourceTree = "<group>"; };
 		94B2C8BE2929617A00087955 /* Action Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Action Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		94B2C8BF2929617A00087955 /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
 		94B2C8C42929617A00087955 /* ActionExtensionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionExtensionViewController.swift; sourceTree = "<group>"; };
@@ -785,7 +784,6 @@
 				D0666A7924C7745A00F3F04B /* Frameworks */,
 				D0BFDAF524FC7C5300C86618 /* HTTP */,
 				947873BB297E0F9000CACEFE /* Identity.xcconfig */,
-				947873BC297E1F7B00CACEFE /* Identity.xcconfig.example.txt */,
 				D0BECB952501B3DD002C1B13 /* Keychain */,
 				D0C7D45624F76169001EBDBB /* Localizations */,
 				D0E0F1E424FC49FC002C04BF /* Mastodon */,

--- a/Feditext.xcodeproj/project.pbxproj
+++ b/Feditext.xcodeproj/project.pbxproj
@@ -329,6 +329,8 @@
 		68B039892934360A003570DD /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
 		68B0398A2934360A003570DD /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = uk; path = uk.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		75F7B3CB291F51D300FDE7C7 /* SwipeableNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableNavigationController.swift; sourceTree = "<group>"; };
+		947873BB297E0F9000CACEFE /* Identity.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Identity.xcconfig; sourceTree = "<group>"; };
+		947873BC297E1F7B00CACEFE /* Identity.xcconfig.example.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = Identity.xcconfig.example.txt; sourceTree = "<group>"; };
 		94B2C8BE2929617A00087955 /* Action Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "Action Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
 		94B2C8BF2929617A00087955 /* UniformTypeIdentifiers.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UniformTypeIdentifiers.framework; path = System/Library/Frameworks/UniformTypeIdentifiers.framework; sourceTree = SDKROOT; };
 		94B2C8C42929617A00087955 /* ActionExtensionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionExtensionViewController.swift; sourceTree = "<group>"; };
@@ -782,6 +784,8 @@
 				D0C7D46824F76169001EBDBB /* Extensions */,
 				D0666A7924C7745A00F3F04B /* Frameworks */,
 				D0BFDAF524FC7C5300C86618 /* HTTP */,
+				947873BB297E0F9000CACEFE /* Identity.xcconfig */,
+				947873BC297E1F7B00CACEFE /* Identity.xcconfig.example.txt */,
 				D0BECB952501B3DD002C1B13 /* Keychain */,
 				D0C7D45624F76169001EBDBB /* Localizations */,
 				D0E0F1E424FC49FC002C04BF /* Mastodon */,
@@ -1612,7 +1616,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = XW9CQ4A58Z;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Action Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Open in Metatext";
@@ -1624,12 +1627,12 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.7.2;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.gotgoat.metatext.action-extension";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(FEDITEXT_BUNDLE_ID_BASE).action-extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1645,7 +1648,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = XW9CQ4A58Z;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "Action Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Open in Metatext";
@@ -1657,12 +1659,12 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.7.2;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.gotgoat.metatext.action-extension";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(FEDITEXT_BUNDLE_ID_BASE).action-extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1672,6 +1674,7 @@
 		};
 		D047FAB424C3E21200AF17C5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 947873BB297E0F9000CACEFE /* Identity.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
@@ -1735,6 +1738,7 @@
 		};
 		D047FAB524C3E21200AF17C5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 947873BB297E0F9000CACEFE /* Identity.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
@@ -1799,7 +1803,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = XW9CQ4A58Z;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "Supporting Files/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Feditext;
@@ -1810,11 +1813,11 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.7.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.gotgoat.metatext;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(FEDITEXT_BUNDLE_ID_BASE)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1831,7 +1834,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = XW9CQ4A58Z;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = "Supporting Files/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = Feditext;
@@ -1842,11 +1844,11 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.7.2;
-				PRODUCT_BUNDLE_IDENTIFIER = com.gotgoat.metatext;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(FEDITEXT_BUNDLE_ID_BASE)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1862,7 +1864,6 @@
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = XW9CQ4A58Z;
 				INFOPLIST_FILE = Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1870,7 +1871,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.gotgoat.Unit-Tests";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(FEDITEXT_BUNDLE_ID_BASE).Unit-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1891,7 +1892,6 @@
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = XW9CQ4A58Z;
 				INFOPLIST_FILE = Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1899,7 +1899,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "com.gotgoat.Unit-Tests";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(FEDITEXT_BUNDLE_ID_BASE).Unit-Tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1918,7 +1918,6 @@
 				CODE_SIGN_ENTITLEMENTS = "Share Extension/Share Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
-				DEVELOPMENT_TEAM = XW9CQ4A58Z;
 				GCC_PREPROCESSOR_DEFINITIONS = "DEBUG=1";
 				INFOPLIST_FILE = "Share Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.2;
@@ -1928,11 +1927,11 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.7.2;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.gotgoat.metatext.share-extension";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(FEDITEXT_BUNDLE_ID_BASE).share-extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG IS_SHARE_EXTENSION";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1945,7 +1944,6 @@
 				CODE_SIGN_ENTITLEMENTS = "Share Extension/Share Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
-				DEVELOPMENT_TEAM = XW9CQ4A58Z;
 				GCC_PREPROCESSOR_DEFINITIONS = "";
 				INFOPLIST_FILE = "Share Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.2;
@@ -1955,11 +1953,11 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.7.2;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.gotgoat.metatext.share-extension";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(FEDITEXT_BUNDLE_ID_BASE).share-extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_SHARE_EXTENSION;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1973,7 +1971,6 @@
 				CODE_SIGN_ENTITLEMENTS = "Notification Service Extension/Notification Service Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
-				DEVELOPMENT_TEAM = XW9CQ4A58Z;
 				INFOPLIST_FILE = "Notification Service Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -1982,11 +1979,11 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.7.2;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.gotgoat.metatext.notification-service-extension";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(FEDITEXT_BUNDLE_ID_BASE).notification-service-extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -1998,7 +1995,6 @@
 				CODE_SIGN_ENTITLEMENTS = "Notification Service Extension/Notification Service Extension.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 3;
-				DEVELOPMENT_TEAM = XW9CQ4A58Z;
 				INFOPLIST_FILE = "Notification Service Extension/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2007,11 +2003,11 @@
 					"@executable_path/../../Frameworks",
 				);
 				MARKETING_VERSION = 1.7.2;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.gotgoat.metatext.notification-service-extension";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(FEDITEXT_BUNDLE_ID_BASE).notification-service-extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;

--- a/Identity.xcconfig
+++ b/Identity.xcconfig
@@ -1,0 +1,5 @@
+// Copy this file to Identity.xcconfig,
+// changing the development team and bundle ID to the one you use.
+
+DEVELOPMENT_TEAM = XW9CQ4A58Z
+FEDITEXT_BUNDLE_ID_BASE = com.gotgoat.feditext

--- a/Notification Service Extension/Info.plist
+++ b/Notification Service Extension/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>Feditext bundle ID base</key>
+	<string>$(FEDITEXT_BUNDLE_ID_BASE)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/Notification Service Extension/Notification Service Extension.entitlements
+++ b/Notification Service Extension/Notification Service Extension.entitlements
@@ -6,13 +6,13 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.gotgoat.metatext</string>
+		<string>group.$(FEDITEXT_BUNDLE_ID_BASE)</string>
 	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.metabolist.metatext</string>
+		<string>$(AppIdentifierPrefix)$(FEDITEXT_BUNDLE_ID_BASE)</string>
 	</array>
 </dict>
 </plist>

--- a/ServiceLayer/Sources/ServiceLayer/Entities/AppEnvironment.swift
+++ b/ServiceLayer/Sources/ServiceLayer/Entities/AppEnvironment.swift
@@ -43,7 +43,15 @@ public struct AppEnvironment {
 }
 
 public extension AppEnvironment {
-    static let appGroup = "group.com.gotgoat.metatext"
+    /// Makes it possible to change the bundle ID of the app and all of its extensions from `Identify.xcconfig`.
+    static var bundleIDBase: String {
+        // swiftlint:disable:next force_cast
+        Bundle.main.infoDictionary!["Feditext bundle ID base"] as! String
+    }
+
+    static var appGroup: String {
+        "group.\(bundleIDBase)"
+    }
 
     static func live(userNotificationCenter: UNUserNotificationCenter,
                      reduceMotion: @escaping () -> Bool,

--- a/Share Extension/Info.plist
+++ b/Share Extension/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>Feditext bundle ID base</key>
+	<string>$(FEDITEXT_BUNDLE_ID_BASE)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/Share Extension/Share Extension.entitlements
+++ b/Share Extension/Share Extension.entitlements
@@ -6,13 +6,13 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.gotgoat.metatext</string>
+		<string>group.$(FEDITEXT_BUNDLE_ID_BASE)</string>
 	</array>
 	<key>com.apple.security.network.client</key>
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.metabolist.metatext</string>
+		<string>$(AppIdentifierPrefix)$(FEDITEXT_BUNDLE_ID_BASE)</string>
 	</array>
 </dict>
 </plist>

--- a/Supporting Files/Info.plist
+++ b/Supporting Files/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>Feditext bundle ID base</key>
+	<string>$(FEDITEXT_BUNDLE_ID_BASE)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
@@ -126,7 +128,7 @@
 			<key>CFBundleURLIconFile</key>
 			<string>AppIconClassic@3x</string>
 			<key>CFBundleURLName</key>
-			<string>com.gotgoat.metatext</string>
+			<string>$(FEDITEXT_BUNDLE_ID_BASE)</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>feditext</string>

--- a/Supporting Files/Metatext.entitlements
+++ b/Supporting Files/Metatext.entitlements
@@ -15,13 +15,19 @@
 	<true/>
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.gotgoat.metatext</string>
+		<string>group.$(FEDITEXT_BUNDLE_ID_BASE)</string>
 	</array>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.personal-information.photos-library</key>
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.gotgoat.metatext</string>
+		<string>$(AppIdentifierPrefix)$(FEDITEXT_BUNDLE_ID_BASE)</string>
 	</array>
 </dict>
 </plist>

--- a/Tests/Info.plist
+++ b/Tests/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>Feditext bundle ID base</key>
+	<string>$(FEDITEXT_BUNDLE_ID_BASE)</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/ViewModels/Sources/PreviewViewModels/PreviewViewModels.swift
+++ b/ViewModels/Sources/PreviewViewModels/PreviewViewModels.swift
@@ -52,7 +52,7 @@ extension ContentDatabase {
         id: identityId,
         useHomeTimelineLastReadId: false,
         inMemory: true,
-        appGroup: "group.com.gotgoat.metatext",
+        appGroup: "group.test.example",
         keychain: MockKeychain.self)
 }
 


### PR DESCRIPTION
- macOS support (currently using Catalyst with iPad idiom, some controls need to be updated for macOS idiom)
- The bundle ID and dev team are now in `Identity.xcconfig` so they can be changed easily for local testing (like Mac builds)

To take advantage of the new `.xcconfig` file, run `git update-index --skip-worktree Identity.xcconfig` and then put your own bundle ID and dev team in the file. Git should ignore it when tracking changes. This makes it easier for me to produce local test builds of Feditext that aren't ready for merging yet (otherwise Xcode will complain that I don't own the bundle ID and am not a member of that dev team).