### PR TITLE
User profile: hide boosts

### DIFF
--- a/DB/Sources/DB/Entities/ProfileCollection.swift
+++ b/DB/Sources/DB/Entities/ProfileCollection.swift
@@ -5,5 +5,6 @@ import Foundation
 public enum ProfileCollection: String, Codable, CaseIterable {
     case statuses
     case statusesAndReplies
+    case statusesAndBoosts
     case media
 }

--- a/Extensions/ProfileCollection+Extensions.swift
+++ b/Extensions/ProfileCollection+Extensions.swift
@@ -20,6 +20,13 @@ extension ProfileCollection {
             default:
                 return NSLocalizedString("account.statuses-and-replies.post", comment: "")
             }
+        case .statusesAndBoosts:
+            switch statusWord {
+            case .toot:
+                return NSLocalizedString("account.statuses-and-boosts.toot", comment: "")
+            default:
+                return NSLocalizedString("account.statuses-and-boosts.post", comment: "")
+            }
         case .media:
             return NSLocalizedString("account.media", comment: "")
         }

--- a/Extensions/ProfileCollection+Extensions.swift
+++ b/Extensions/ProfileCollection+Extensions.swift
@@ -4,7 +4,7 @@ import Foundation
 import ViewModels
 
 extension ProfileCollection {
-    func title(statusWord: AppPreferences.StatusWord) -> String {
+    func title(statusWord: AppPreferences.StatusWord, shorten: Bool) -> String {
         switch self {
         case .statuses:
             switch statusWord {
@@ -14,18 +14,22 @@ extension ProfileCollection {
                 return NSLocalizedString("account.statuses.post", comment: "")
             }
         case .statusesAndReplies:
-            switch statusWord {
-            case .toot:
+            switch (statusWord, shorten) {
+            case (.toot, false):
                 return NSLocalizedString("account.statuses-and-replies.toot", comment: "")
-            default:
+            case (.post, false):
                 return NSLocalizedString("account.statuses-and-replies.post", comment: "")
+            case (_, true):
+                return NSLocalizedString("account.statuses-and-replies.short", comment: "")
             }
         case .statusesAndBoosts:
-            switch statusWord {
-            case .toot:
+            switch (statusWord, shorten) {
+            case (.toot, false):
                 return NSLocalizedString("account.statuses-and-boosts.toot", comment: "")
-            default:
+            case (.post, false):
                 return NSLocalizedString("account.statuses-and-boosts.post", comment: "")
+            case (_, true):
+                return NSLocalizedString("account.statuses-and-boosts.short", comment: "")
             }
         case .media:
             return NSLocalizedString("account.media", comment: "")

--- a/Localizations/en.lproj/Localizable.strings
+++ b/Localizations/en.lproj/Localizable.strings
@@ -50,8 +50,10 @@
 "account.statuses.toot" = "Toots";
 "account.statuses-and-replies.post" = "Posts & Replies";
 "account.statuses-and-replies.toot" = "Toots & Replies";
+"account.statuses-and-replies.short" = "& Replies";
 "account.statuses-and-boosts.post" = "Posts & Boosts";
 "account.statuses-and-boosts.toot" = "Toots & Boosts";
+"account.statuses-and-boosts.short" = "& Boosts";
 "account.media" = "Media";
 "account.show-reblogs" = "Show boosts";
 "account.show-reblogs.confirm-%@" = "Show boosts from %@?";

--- a/Localizations/en.lproj/Localizable.strings
+++ b/Localizations/en.lproj/Localizable.strings
@@ -50,6 +50,8 @@
 "account.statuses.toot" = "Toots";
 "account.statuses-and-replies.post" = "Posts & Replies";
 "account.statuses-and-replies.toot" = "Toots & Replies";
+"account.statuses-and-boosts.post" = "Posts & Boosts";
+"account.statuses-and-boosts.toot" = "Toots & Boosts";
 "account.media" = "Media";
 "account.show-reblogs" = "Show boosts";
 "account.show-reblogs.confirm-%@" = "Show boosts from %@?";

--- a/Localizations/es.lproj/Localizable.strings
+++ b/Localizations/es.lproj/Localizable.strings
@@ -50,6 +50,8 @@
 "account.statuses.toot" = "Toots";
 "account.statuses-and-replies.post" = "Publicaciones y respuestas";
 "account.statuses-and-replies.toot" = "Toots y respuestas";
+"account.statuses-and-boosts.post" = "Publicaciones y boosts";
+"account.statuses-and-boosts.toot" = "Toots y boosts";
 "account.media" = "Multimedia";
 "account.show-reblogs" = "Mostrar boosts";
 "account.show-reblogs.confirm-%@" = "¿Mostrar boosts de %@?";

--- a/Localizations/es.lproj/Localizable.strings
+++ b/Localizations/es.lproj/Localizable.strings
@@ -50,8 +50,10 @@
 "account.statuses.toot" = "Toots";
 "account.statuses-and-replies.post" = "Publicaciones y respuestas";
 "account.statuses-and-replies.toot" = "Toots y respuestas";
+"account.statuses-and-replies.short" = "y respuestas";
 "account.statuses-and-boosts.post" = "Publicaciones y boosts";
 "account.statuses-and-boosts.toot" = "Toots y boosts";
+"account.statuses-and-boosts.short" = "y boosts";
 "account.media" = "Multimedia";
 "account.show-reblogs" = "Mostrar boosts";
 "account.show-reblogs.confirm-%@" = "¿Mostrar boosts de %@?";

--- a/MastodonAPI/Sources/MastodonAPI/Endpoints/StatusesEndpoint.swift
+++ b/MastodonAPI/Sources/MastodonAPI/Endpoints/StatusesEndpoint.swift
@@ -9,7 +9,7 @@ public enum StatusesEndpoint {
     case timelinesTag(String)
     case timelinesHome
     case timelinesList(id: List.Id)
-    case accountsStatuses(id: Account.Id, excludeReplies: Bool, onlyMedia: Bool, pinned: Bool)
+    case accountsStatuses(id: Account.Id, excludeReplies: Bool, excludeReblogs: Bool, onlyMedia: Bool, pinned: Bool)
     case favourites
     case bookmarks
 }
@@ -38,7 +38,7 @@ extension StatusesEndpoint: Endpoint {
             return ["home"]
         case let .timelinesList(id):
             return ["list", id]
-        case let .accountsStatuses(id, _, _, _):
+        case let .accountsStatuses(id, _, _, _, _):
             return [id, "statuses"]
         case .favourites:
             return ["favourites"]
@@ -51,8 +51,9 @@ extension StatusesEndpoint: Endpoint {
         switch self {
         case let .timelinesPublic(local):
             return [URLQueryItem(name: "local", value: String(local))]
-        case let .accountsStatuses(_, excludeReplies, onlyMedia, pinned):
+        case let .accountsStatuses(_, excludeReplies, excludeReblogs, onlyMedia, pinned):
             return [URLQueryItem(name: "exclude_replies", value: String(excludeReplies)),
+                    URLQueryItem(name: "exclude_reblogs", value: String(excludeReblogs)),
                     URLQueryItem(name: "only_media", value: String(onlyMedia)),
                     URLQueryItem(name: "pinned", value: String(pinned))]
         default:

--- a/ServiceLayer/Sources/ServiceLayer/Extensions/Timeline+Extensions.swift
+++ b/ServiceLayer/Sources/ServiceLayer/Extensions/Timeline+Extensions.swift
@@ -17,23 +17,32 @@ extension Timeline {
             return .timelinesTag(tag)
         case let .profile(accountId, profileCollection):
             let excludeReplies: Bool
+            let excludeReblogs: Bool
             let onlyMedia: Bool
 
             switch profileCollection {
             case .statuses:
                 excludeReplies = true
+                excludeReblogs = true
                 onlyMedia = false
             case .statusesAndReplies:
                 excludeReplies = false
+                excludeReblogs = true
+                onlyMedia = false
+            case .statusesAndBoosts:
+                excludeReplies = false
+                excludeReblogs = false
                 onlyMedia = false
             case .media:
                 excludeReplies = true
+                excludeReblogs = true
                 onlyMedia = true
             }
 
             return .accountsStatuses(
                 id: accountId,
                 excludeReplies: excludeReplies,
+                excludeReblogs: excludeReblogs,
                 onlyMedia: onlyMedia,
                 pinned: false)
         case .favorites:

--- a/ServiceLayer/Sources/ServiceLayer/Services/ProfileService.swift
+++ b/ServiceLayer/Sources/ServiceLayer/Services/ProfileService.swift
@@ -94,6 +94,7 @@ public extension ProfileService {
             StatusesEndpoint.accountsStatuses(
                 id: id,
                 excludeReplies: true,
+                excludeReblogs: true,
                 onlyMedia: false,
                 pinned: true))
             .flatMap { contentDatabase.insert(pinnedStatuses: $0, accountId: id) }

--- a/ViewModels/Sources/ViewModels/View Models/ReportViewModel.swift
+++ b/ViewModels/Sources/ViewModels/View Models/ReportViewModel.swift
@@ -18,7 +18,7 @@ public final class ReportViewModel: CollectionItemsViewModel {
 
         super.init(
             collectionService: identityContext.service.navigationService.timelineService(
-                timeline: .profile(accountId: accountService.account.id, profileCollection: .statusesAndReplies)),
+                timeline: .profile(accountId: accountService.account.id, profileCollection: .statusesAndBoosts)),
             identityContext: identityContext)
 
         if let statusId = statusId {


### PR DESCRIPTION
Add a 4th profile tab that shows boosts, while removing boosts from the Posts and Posts & Replies tabs.

This implements the UI side of `exclude_reblogs`, a feature that I proposed for Mastodon in mastodon/mastodon#9606 and which Eugen added in mastodon/mastodon#9640. The Mastodon web UI equivalent has been workshopped a bit in mastodon/mastodon#11120; a full filter panel might be nice, as suggested there, but I think the 4-tab design is less fussy.