### PR TITLE
Revert to count-based folding

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,8 @@
 disabled_rules:
   - identifier_name
   - type_name
+  - cyclomatic_complexity
+  - function_body_length
 opt_in_rules:
   - sorted_imports
 

--- a/Localizations/en.lproj/Localizable.strings
+++ b/Localizations/en.lproj/Localizable.strings
@@ -238,7 +238,7 @@
 "preferences.filters" = "Filters";
 "preferences.links.open-in-default-browser" = "Open links in default browser";
 "preferences.links.use-universal-links" = "Open links in other apps when available";
-"preferences.long-posts.fold" = "Fold long posts";
+"preferences.long-content.fold" = "Fold long text";
 "preferences.notification-types" = "Notification Types";
 "preferences.notification-types.follow" = "Follow";
 "preferences.notification-types.favourite" = "Favorite";

--- a/Localizations/es.lproj/Localizable.strings
+++ b/Localizations/es.lproj/Localizable.strings
@@ -238,6 +238,7 @@
 "preferences.filters" = "Filtros";
 "preferences.links.open-in-default-browser" = "Abrir enlaces en el navegador predeterminado";
 "preferences.links.use-universal-links" = "Abrir enlaces en otras aplicaciones cuando estén disponibles";
+"preferences.long-content.fold" = "Doblar texto largo";
 "preferences.notification-types" = "Tipos de notificación";
 "preferences.notification-types.follow" = "Seguir";
 "preferences.notification-types.favourite" = "Favorito";

--- a/Views/SwiftUI/PreferencesView.swift
+++ b/Views/SwiftUI/PreferencesView.swift
@@ -145,7 +145,7 @@ struct PreferencesView: View {
                            isOn: $identityContext.appPreferences.animateHeaders)
                     Toggle("preferences.hide-content-warning-button",
                            isOn: $identityContext.appPreferences.hideContentWarningButton)
-                    Toggle("preferences.long-posts.fold",
+                    Toggle("preferences.long-content.fold",
                            isOn: $identityContext.appPreferences.foldLongPosts)
                 }
                 if viewModel.identityContext.identity.authenticated

--- a/Views/UIKit/Content Views/StatusView.swift
+++ b/Views/UIKit/Content Views/StatusView.swift
@@ -77,7 +77,7 @@ final class StatusView: UIView {
     }
 
     override func accessibilityActivate() -> Bool {
-        if reportSelectionSwitch.isHidden, !bodyView.shouldShowContent {
+        if reportSelectionSwitch.isHidden, !statusConfiguration.viewModel.shouldShowContent {
             statusConfiguration.viewModel.toggleShowContent()
             accessibilityAttributedLabel = accessibilityAttributedLabel(forceShowContent: true)
 


### PR DESCRIPTION
Takes context-dependent layout calculations out of the decision to fold, which should fix the weird behavior people are seeing where a post can't decide whether it's folded or not. Also adds some constraints to the Show More button to prevent it from being vertically squashed or stretched.

Linting: disables cyclomatic complexity and function body length, which are, in my experience, low-value warnings in this codebase, or anywhere for that matter.

Fixes #23.