### PR TITLE
Add a user preference to display rounded rectangle avatars

### DIFF
--- a/Feditext.xcodeproj/project.pbxproj
+++ b/Feditext.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		14FC7D32292A556E00567DBC /* UIFont+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14FC7D31292A556E00567DBC /* UIFont+Extensions.swift */; };
+		5E91C1272A2E0A95008CD718 /* AccountHeaderViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E91C1262A2E0A95008CD718 /* AccountHeaderViewRepresentable.swift */; };
 		75F7B3CC291F51D300FDE7C7 /* SwipeableNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75F7B3CB291F51D300FDE7C7 /* SwipeableNavigationController.swift */; };
 		941F79CC2A243418007FCC65 /* MultiNotificationContentConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941F79CB2A243418007FCC65 /* MultiNotificationContentConfiguration.swift */; };
 		941F79CE2A243446007FCC65 /* MultiNotificationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941F79CD2A243446007FCC65 /* MultiNotificationTableViewCell.swift */; };
@@ -317,6 +318,7 @@
 		14FC7D31292A556E00567DBC /* UIFont+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extensions.swift"; sourceTree = "<group>"; };
 		2805F2DF26044E8900670835 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2805F2E026044E8900670835 /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = de; path = de.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
+		5E91C1262A2E0A95008CD718 /* AccountHeaderViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountHeaderViewRepresentable.swift; sourceTree = "<group>"; };
 		682EA140292B27D4007B0417 /* eu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = eu; path = eu.lproj/Localizable.strings; sourceTree = "<group>"; };
 		682EA141292B27D4007B0417 /* eu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = eu; path = eu.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		682EA142292B29B4007B0417 /* el */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = el; path = el.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -377,7 +379,7 @@
 		D007023D25562A2800F38136 /* ConversationAvatarsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationAvatarsView.swift; sourceTree = "<group>"; };
 		D0070251255921B100F38136 /* AccountFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountFieldView.swift; sourceTree = "<group>"; };
 		D00CB22925C92C0F008EF267 /* Attachment+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Attachment+Extensions.swift"; sourceTree = "<group>"; };
-		D00CB2EC2533ACC00080096B /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
+		D00CB2EC2533ACC00080096B /* StatusView.swift */ = {isa = PBXFileReference; indentWidth = 3; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
 		D01EF22325182B1F00650C6B /* AccountHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountHeaderView.swift; sourceTree = "<group>"; };
 		D01F41D624F880C400D55A2D /* TouchFallthroughTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TouchFallthroughTextView.swift; sourceTree = "<group>"; };
 		D01F41E224F8889700D55A2D /* AttachmentsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AttachmentsView.swift; sourceTree = "<group>"; };
@@ -627,6 +629,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5E91C1252A2E09ED008CD718 /* View Representables */ = {
+			isa = PBXGroup;
+			children = (
+				5E91C1262A2E0A95008CD718 /* AccountHeaderViewRepresentable.swift */,
+			);
+			path = "View Representables";
+			sourceTree = "<group>";
+		};
 		9432DE2429A158460007C2BF /* Docs */ = {
 			isa = PBXGroup;
 			children = (
@@ -729,13 +739,14 @@
 				D07F4D9725D493E300F61133 /* MuteView.swift */,
 				D08B9F0F25CB8E060062D040 /* NotificationPreferencesView.swift */,
 				D0C7D42D24F76169001EBDBB /* NotificationTypesPreferencesView.swift */,
+				947E728E29A9618900155DD2 /* EditNoteView.swift */,
 				94E6C2492991A23C003771D1 /* Preferences */,
 				D0B32F4F250B373600311912 /* RegistrationView.swift */,
 				D0C7D42724F76169001EBDBB /* RootView.swift */,
 				D0C7D42924F76169001EBDBB /* SecondaryNavigationView.swift */,
 				94B0BCD229859B750075E234 /* StatusEditHistoryView.swift */,
+				5E91C1252A2E09ED008CD718 /* View Representables */,
 				D021A66925C3E19D008A0C0D /* View Controller Representables */,
-				947E728E29A9618900155DD2 /* EditNoteView.swift */,
 			);
 			path = SwiftUI;
 			sourceTree = "<group>";
@@ -1484,6 +1495,7 @@
 				D0D93EBA25D9C70400C622ED /* AutocompleteItemView.swift in Sources */,
 				D0C7D4C424F7616A001EBDBB /* AppDelegate.swift in Sources */,
 				D0C7D49924F7616A001EBDBB /* AddIdentityView.swift in Sources */,
+				5E91C1272A2E0A95008CD718 /* AccountHeaderViewRepresentable.swift in Sources */,
 				D0DDA77F25C6058300FA0F91 /* ExploreSectionHeaderView.swift in Sources */,
 				D0FCC105259C4E61000B67DF /* ComposeStatusViewController.swift in Sources */,
 				D087671625BAA8C0001FDD43 /* ExploreViewController.swift in Sources */,

--- a/Localizations/en.lproj/Localizable.strings
+++ b/Localizations/en.lproj/Localizable.strings
@@ -269,6 +269,9 @@
 "preferences.media.avatars.animate.everywhere" = "Everywhere";
 "preferences.media.avatars.animate.profiles" = "In profiles";
 "preferences.media.avatars.animate.never" = "Never";
+"preferences.media.avatars.display.shape" = "Display avatar shape";
+"preferences.media.avatars.display.shape.circle" = "Circle";
+"preferences.media.avatars.display.shape.rounded-rectangle" = "Rounded Rectangle";
 "preferences.media.custom-emojis.animate" = "Animate custom emoji";
 "preferences.media.headers.animate" = "Animate profile headers";
 "preferences.media.autoplay" = "Autoplay";

--- a/ServiceLayer/Sources/ServiceLayer/Services/ProfileService.swift
+++ b/ServiceLayer/Sources/ServiceLayer/Services/ProfileService.swift
@@ -30,7 +30,7 @@ public struct ProfileService {
             contentDatabase: contentDatabase)
     }
 
-    init(id: Account.Id,
+    public init(id: Account.Id,
          environment: AppEnvironment,
          mastodonAPIClient: MastodonAPIClient,
          contentDatabase: ContentDatabase) {

--- a/ServiceLayer/Sources/ServiceLayer/Utilities/AppPreferences.swift
+++ b/ServiceLayer/Sources/ServiceLayer/Utilities/AppPreferences.swift
@@ -39,6 +39,13 @@ public extension AppPreferences {
 
         public var id: String { rawValue }
     }
+    
+    enum DisplayAvatarShape: String, CaseIterable, Identifiable {
+        case circle
+        case roundedRectangle
+
+        public var id: String { rawValue }
+    }
 
     enum KeyboardType: String, CaseIterable, Identifiable {
         case twitter
@@ -96,6 +103,18 @@ public extension AppPreferences {
             return systemReduceMotion() ? .never : .everywhere
         }
         set { self[.animateAvatars] = newValue.rawValue }
+    }
+    
+    var displayAvatarShape: DisplayAvatarShape {
+        get {
+            if let rawValue = self[.displayAvatarShape] as String?,
+               let value = DisplayAvatarShape(rawValue: rawValue) {
+                return value
+            }
+
+            return .circle
+        }
+        set { self[.displayAvatarShape] = newValue.rawValue }
     }
 
     var keyboardType: KeyboardType {
@@ -252,6 +271,7 @@ private extension AppPreferences {
         case requireDoubleTapToReblog
         case requireDoubleTapToFavorite
         case animateAvatars
+        case displayAvatarShape
         case keyboardType
         case animateHeaders
         case animateCustomEmojis

--- a/View Controllers/MainNavigationViewController.swift
+++ b/View Controllers/MainNavigationViewController.swift
@@ -140,6 +140,13 @@ private extension MainNavigationViewController {
 
         for controller in controllers {
             controller.navigationItem.leftBarButtonItem = secondaryNavigationButton
+            // Apply displayAvatarShape to avatarBackgroundView
+            switch viewModel.identityContext.appPreferences.displayAvatarShape {
+                case .circle:
+                    controller.navigationItem.leftBarButtonItem?.customView?.layer.cornerRadius = .barButtonItemDimension / 2
+                case .roundedRectangle:
+                    controller.navigationItem.leftBarButtonItem?.customView?.layer.cornerRadius = .barButtonItemDimension / 8
+            }
         }
 
         viewControllers = controllers.map(SwipeableNavigationController.init(rootViewController:))

--- a/ViewModels/Sources/PreviewViewModels/PreviewViewModels.swift
+++ b/ViewModels/Sources/PreviewViewModels/PreviewViewModels.swift
@@ -155,4 +155,17 @@ public extension NavigationViewModel {
     )
 }
 
+public extension ProfileViewModel {
+    static let preview = ProfileViewModel(
+        profileService: .init(
+            id: Account.preview.id,
+            environment: environment,
+            mastodonAPIClient: .preview,
+            contentDatabase: .preview
+        ),
+        identityContext: .preview
+        
+    )
+}
+
 // swiftlint:enable force_try

--- a/Views/SwiftUI/Preferences/AppPreferencesSection.swift
+++ b/Views/SwiftUI/Preferences/AppPreferencesSection.swift
@@ -90,6 +90,12 @@ struct AppPreferencesSection: View {
                         Text(option.localizedStringKey).tag(option)
                     }
                 }
+                Picker("preferences.media.avatars.display.shape",
+                       selection: $identityContext.appPreferences.displayAvatarShape) {
+                    ForEach(AppPreferences.DisplayAvatarShape.allCases) { option in
+                        Text(option.localizedStringKey).tag(option)
+                    }
+                }
                 Toggle("preferences.media.custom-emojis.animate",
                        isOn: $identityContext.appPreferences.animateCustomEmojis)
                 Toggle("preferences.media.headers.animate",

--- a/Views/SwiftUI/Preferences/PreferencesView.swift
+++ b/Views/SwiftUI/Preferences/PreferencesView.swift
@@ -66,6 +66,17 @@ extension AppPreferences.AnimateAvatars {
     }
 }
 
+extension AppPreferences.DisplayAvatarShape {
+    var localizedStringKey: LocalizedStringKey {
+        switch self {
+        case .circle:
+            return "preferences.media.avatars.display.shape.circle"
+        case .roundedRectangle:
+            return "preferences.media.avatars.display.shape.rounded-rectangle"
+        }
+    }
+}
+
 extension AppPreferences.KeyboardType {
     var localizedStringKey: LocalizedStringKey {
         switch self {

--- a/Views/SwiftUI/View Representables/AccountHeaderViewRepresentable.swift
+++ b/Views/SwiftUI/View Representables/AccountHeaderViewRepresentable.swift
@@ -1,0 +1,30 @@
+// Copyright © 2023 Metabolist. All rights reserved.
+
+import SwiftUI
+import ViewModels
+
+struct AccountHeaderViewRepresentable: UIViewRepresentable {
+    typealias UIViewType = AccountHeaderView
+    let viewModelClosure: () ->  ProfileViewModel
+    
+    func makeUIView(context: Context) -> AccountHeaderView {
+        return AccountHeaderView(viewModel: viewModelClosure())
+    }
+    
+    func updateUIView(_ uiView: AccountHeaderView, context: Context) {
+        
+    }
+}
+
+#if DEBUG
+import PreviewViewModels
+
+struct AccountHeaderView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            AccountHeaderViewRepresentable(
+                viewModelClosure: {ProfileViewModel.preview})
+        }
+    }
+}
+#endif

--- a/Views/UIKit/AccountHeaderView.swift
+++ b/Views/UIKit/AccountHeaderView.swift
@@ -336,14 +336,28 @@ private extension AccountHeaderView {
         addSubview(avatarBackgroundView)
         avatarBackgroundView.translatesAutoresizingMaskIntoConstraints = false
         avatarBackgroundView.backgroundColor = .systemBackground
-        avatarBackgroundView.layer.cornerRadius = avatarBackgroundViewDimension / 2
+        
+        // Apply displayAvatarShape to avatarBackgroundView
+        switch viewModel.identityContext.appPreferences.displayAvatarShape {
+            case .circle:
+                avatarBackgroundView.layer.cornerRadius = avatarBackgroundViewDimension / 2
+            case .roundedRectangle:
+                avatarBackgroundView.layer.cornerRadius = avatarBackgroundViewDimension / 8
+        }
 
         avatarBackgroundView.addSubview(avatarImageView)
         avatarImageView.translatesAutoresizingMaskIntoConstraints = false
         avatarImageView.contentMode = .scaleAspectFill
         avatarImageView.clipsToBounds = true
         avatarImageView.isUserInteractionEnabled = true
-        avatarImageView.layer.cornerRadius = Self.avatarDimension / 2
+        
+        // Apply displayAvatarShape to avatarImageView
+        switch viewModel.identityContext.appPreferences.displayAvatarShape {
+            case .circle:
+                avatarImageView.layer.cornerRadius = Self.avatarDimension / 2
+            case .roundedRectangle:
+                avatarImageView.layer.cornerRadius = Self.avatarDimension / 8
+        }
 
         avatarImageView.addSubview(avatarButton)
         avatarButton.translatesAutoresizingMaskIntoConstraints = false

--- a/Views/UIKit/CompositionView.swift
+++ b/Views/UIKit/CompositionView.swift
@@ -64,13 +64,21 @@ private extension CompositionView {
 
         addSubview(avatarImageView)
         avatarImageView.translatesAutoresizingMaskIntoConstraints = false
-        avatarImageView.layer.cornerRadius = .avatarDimension / 2
         avatarImageView.clipsToBounds = true
         avatarImageView.setContentHuggingPriority(.required, for: .horizontal)
+        
+        // Apply displayAvatarShape to avatarImageView
+        switch parentViewModel.identityContext.appPreferences.displayAvatarShape {
+            case .circle:
+                avatarImageView.layer.cornerRadius = .avatarDimension / 2
+            case .roundedRectangle:
+                avatarImageView.layer.cornerRadius = .avatarDimension / 8
+        }
 
         changeIdentityButton.translatesAutoresizingMaskIntoConstraints = false
         avatarImageView.addSubview(changeIdentityButton)
         avatarImageView.isUserInteractionEnabled = true
+        
         changeIdentityButton.setBackgroundImage(.highlightedButtonBackground, for: .highlighted)
         changeIdentityButton.showsMenuAsPrimaryAction = true
         changeIdentityButton.menu =

--- a/Views/UIKit/Content Views/AccountView.swift
+++ b/Views/UIKit/Content Views/AccountView.swift
@@ -143,8 +143,16 @@ private extension AccountView {
         stackView.alignment = .top
 
         stackView.addArrangedSubview(avatarImageView)
-        avatarImageView.layer.cornerRadius = .avatarDimension / 2
+
         avatarImageView.clipsToBounds = true
+        
+        // Apply displayAvatarShape to avatarImageView
+        switch accountConfiguration.viewModel.identityContext.appPreferences.displayAvatarShape {
+            case .circle:
+                avatarImageView.layer.cornerRadius = .avatarDimension / 2
+            case .roundedRectangle:
+                avatarImageView.layer.cornerRadius = .avatarDimension / 8
+        }
 
         accountTypeStack.axis = .horizontal
         accountTypeStack.spacing = .ultraCompactSpacing
@@ -375,6 +383,12 @@ private extension AccountView {
         let viewModel = accountConfiguration.viewModel
 
         avatarImageView.sd_setImage(with: viewModel.avatarURL(profile: false))
+        switch accountConfiguration.viewModel.identityContext.appPreferences.displayAvatarShape {
+            case .circle:
+                avatarImageView.layer.cornerRadius = .avatarDimension / 2
+            case .roundedRectangle:
+                avatarImageView.layer.cornerRadius = .avatarDimension / 8
+        }
 
         let mutableDisplayName = NSMutableAttributedString(string: viewModel.displayName)
 

--- a/Views/UIKit/Content Views/IdentityView.swift
+++ b/Views/UIKit/Content Views/IdentityView.swift
@@ -42,10 +42,17 @@ private extension IdentityView {
     func initialSetup() {
         addSubview(imageView)
         imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.layer.cornerRadius = .avatarDimension / 2
         imageView.clipsToBounds = true
         imageView.contentMode = .scaleAspectFill
-
+        
+        // Apply displayAvatarShape to avatarImageView
+        switch identityConfiguration.viewModel.identityContext.appPreferences.displayAvatarShape {
+            case .circle:
+                imageView.layer.cornerRadius = .avatarDimension / 2
+            case .roundedRectangle:
+                imageView.layer.cornerRadius = .avatarDimension / 8
+        }
+        
         let stackView = UIStackView()
 
         addSubview(stackView)
@@ -86,6 +93,13 @@ private extension IdentityView {
 
         imageView.sd_setImage(with: viewModel.identity.image)
         imageView.autoPlayAnimatedImage = viewModel.identityContext.appPreferences.animateAvatars == .everywhere
+    
+        switch viewModel.identityContext.appPreferences.displayAvatarShape {
+            case .circle:
+                imageView.layer.cornerRadius = .avatarDimension / 2
+            case .roundedRectangle:
+                imageView.layer.cornerRadius = .avatarDimension / 8
+        }
 
         if let displayName = viewModel.identity.account?.displayName,
            !displayName.isEmpty {

--- a/Views/UIKit/Content Views/MultiNotificationView.swift
+++ b/Views/UIKit/Content Views/MultiNotificationView.swift
@@ -102,13 +102,20 @@ private extension MultiNotificationView {
             avatarStackView.sendSubviewToBack(avatarContainerView)
             avatarContainerView.translatesAutoresizingMaskIntoConstraints = false
             avatarContainerView.backgroundColor = .systemBackground
-            avatarContainerView.layer.cornerRadius = .avatarDimension / 2
             avatarContainerView.clipsToBounds = true
 
             let avatarImageView = SDAnimatedImageView()
             avatarContainerView.addSubview(avatarImageView)
             avatarImageView.translatesAutoresizingMaskIntoConstraints = false
-            avatarImageView.layer.cornerRadius = .avatarDimension / 2
+            
+            // Apply displayAvatarShape to avatarImageView
+            switch multiNotificationConfiguration.viewModel.identityContext.appPreferences.displayAvatarShape {
+                case .circle:
+                    avatarImageView.layer.cornerRadius = .avatarDimension / 2
+                case .roundedRectangle:
+                    avatarImageView.layer.cornerRadius = .avatarDimension / 8
+            }
+            
             avatarImageView.clipsToBounds = true
             avatarImageView.alpha = CGFloat(maxAvatarCount - i) / CGFloat(maxAvatarCount)
 
@@ -200,6 +207,14 @@ private extension MultiNotificationView {
             if i < displayedAccountViewModels.count {
                 avatarImageView.sd_setImage(with: displayedAccountViewModels[i].avatarURL())
                 avatarImageView.superview?.isHidden = false
+                
+                // Apply displayAvatarShape to avatarImageView
+                switch viewModel.identityContext.appPreferences.displayAvatarShape {
+                    case .circle:
+                        avatarImageView.layer.cornerRadius = .avatarDimension / 2
+                    case .roundedRectangle:
+                        avatarImageView.layer.cornerRadius = .avatarDimension / 8
+                }
             } else {
                 avatarImageView.sd_setImage(with: nil)
                 avatarImageView.superview?.isHidden = true

--- a/Views/UIKit/Content Views/NotificationView.swift
+++ b/Views/UIKit/Content Views/NotificationView.swift
@@ -109,8 +109,15 @@ private extension NotificationView {
         iconImageView.contentMode = .scaleAspectFit
         iconImageView.setContentHuggingPriority(.required, for: .horizontal)
 
-        avatarImageView.layer.cornerRadius = .avatarDimension / 2
         avatarImageView.clipsToBounds = true
+        
+        // Apply displayAvatarShape to avatarImageView
+        switch notificationConfiguration.viewModel.identityContext.appPreferences.displayAvatarShape {
+            case .circle:
+                avatarImageView.layer.cornerRadius = .avatarDimension / 2
+            case .roundedRectangle:
+                avatarImageView.layer.cornerRadius = .avatarDimension / 8
+        }
 
         let avatarHeightConstraint = avatarImageView.heightAnchor.constraint(equalToConstant: .avatarDimension)
 
@@ -169,6 +176,14 @@ private extension NotificationView {
         let viewModel = notificationConfiguration.viewModel
 
         avatarImageView.sd_setImage(with: viewModel.accountViewModel.avatarURL())
+        
+        // Apply displayAvatarShape to avatarImageView
+        switch notificationConfiguration.viewModel.identityContext.appPreferences.displayAvatarShape {
+            case .circle:
+                avatarImageView.layer.cornerRadius = .avatarDimension / 2
+            case .roundedRectangle:
+                avatarImageView.layer.cornerRadius = .avatarDimension / 8
+        }
 
         switch viewModel.type {
         case .follow:

--- a/Views/UIKit/Content Views/StatusView.swift
+++ b/Views/UIKit/Content Views/StatusView.swift
@@ -419,12 +419,20 @@ private extension StatusView {
 
         avatarContainerView.addSubview(avatarImageView)
         avatarImageView.translatesAutoresizingMaskIntoConstraints = false
-        avatarImageView.layer.cornerRadius = .avatarDimension / 2
         avatarImageView.clipsToBounds = true
 
         avatarButton.translatesAutoresizingMaskIntoConstraints = false
         avatarImageView.addSubview(avatarButton)
         avatarImageView.isUserInteractionEnabled = true
+        
+        // Apply displayAvatarShape to avatarImageView
+        switch statusConfiguration.viewModel.identityContext.appPreferences.displayAvatarShape {
+            case .circle:
+                avatarImageView.layer.cornerRadius = .avatarDimension / 2
+            case .roundedRectangle:
+                avatarImageView.layer.cornerRadius = .avatarDimension / 8
+        }
+        
         avatarButton.setBackgroundImage(.highlightedButtonBackground, for: .highlighted)
 
         avatarButton.addAction(
@@ -433,10 +441,18 @@ private extension StatusView {
 
         avatarContainerView.addSubview(rebloggerAvatarImageView)
         rebloggerAvatarImageView.translatesAutoresizingMaskIntoConstraints = false
-        rebloggerAvatarImageView.layer.cornerRadius = .avatarDimension / 4
         rebloggerAvatarImageView.clipsToBounds = true
         rebloggerAvatarImageView.isHidden = true
-
+        
+        // Apply displayAvatarShape to rebloggerAvatarImageView
+        switch statusConfiguration.viewModel.identityContext.appPreferences.displayAvatarShape {
+            case .circle:
+                // Radius of the reblogger's avatar is half of the normal avatar
+                rebloggerAvatarImageView.layer.cornerRadius = .avatarDimension / 4
+            case .roundedRectangle:
+                rebloggerAvatarImageView.layer.cornerRadius = .avatarDimension / 16
+        }
+        
         for view in [inReplyToView, hasReplyFollowingView] {
             addSubview(view)
             view.translatesAutoresizingMaskIntoConstraints = false
@@ -509,9 +525,25 @@ private extension StatusView {
 
         avatarWidthConstraint.constant = avatarDimension
         avatarHeightConstraint.constant = avatarDimension
-        avatarImageView.layer.cornerRadius = avatarDimension / 2
+        
+        // Apply displayAvatarShape to avatarImageView
+        switch statusConfiguration.viewModel.identityContext.appPreferences.displayAvatarShape {
+            case .circle:
+                avatarImageView.layer.cornerRadius = avatarDimension / 2
+            case .roundedRectangle:
+                avatarImageView.layer.cornerRadius = avatarDimension / 8
+        }
+        
         rebloggerAvatarImageView.isHidden = !viewModel.isReblog
         rebloggerAvatarImageView.sd_setImage(with: viewModel.isReblog ? viewModel.rebloggerAvatarURL : nil)
+        
+        // Apply displayAvatarShape to rebloggerAvatarImageView
+        switch statusConfiguration.viewModel.identityContext.appPreferences.displayAvatarShape {
+            case .circle:
+                rebloggerAvatarImageView.layer.cornerRadius = avatarDimension / 4
+            case .roundedRectangle:
+                rebloggerAvatarImageView.layer.cornerRadius = avatarDimension / 16
+        }
 
         if isContextParent, avatarContainerView.superview !== nameAccountContainerStackView {
             nameAccountContainerStackView.insertArrangedSubview(avatarContainerView, at: 0)

--- a/Views/UIKit/ConversationAvatarsView.swift
+++ b/Views/UIKit/ConversationAvatarsView.swift
@@ -53,8 +53,15 @@ final class ConversationAvatarsView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-
-        layer.cornerRadius = bounds.height / 2
+        // Apply displayAvatarShape to avatarImageView
+        switch viewModel?.identityContext.appPreferences.displayAvatarShape {
+            case .circle:
+                layer.cornerRadius = bounds.height / 2
+            case .roundedRectangle:
+                layer.cornerRadius = bounds.height / 8
+            case .none:
+                layer.cornerRadius = bounds.height / 2
+        }
     }
 }
 
@@ -84,5 +91,14 @@ private extension ConversationAvatarsView {
             containerStackView.topAnchor.constraint(equalTo: topAnchor),
             containerStackView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ])
+        
+        switch viewModel?.identityContext.appPreferences.displayAvatarShape {
+            case .circle:
+                layer.cornerRadius = bounds.height / 2
+            case .roundedRectangle:
+                layer.cornerRadius = bounds.height / 8
+            case .none:
+                layer.cornerRadius = bounds.height / 2
+        }
     }
 }

--- a/Views/UIKit/SecondaryNavigationButton.swift
+++ b/Views/UIKit/SecondaryNavigationButton.swift
@@ -17,9 +17,9 @@ final class SecondaryNavigationButton: UIBarButtonItem {
 
         button.accessibilityLabel = NSLocalizedString("secondary-navigation-button.accessibility-title", comment: "")
         button.imageView?.contentMode = .scaleAspectFill
-        button.layer.cornerRadius = .barButtonItemDimension / 2
         button.clipsToBounds = true
-
+        button.layer.cornerRadius = .barButtonItemDimension / 2
+        
         customView = button
 
         NSLayoutConstraint.activate([

--- a/Views/UIKit/SecondaryNavigationTitleView.swift
+++ b/Views/UIKit/SecondaryNavigationTitleView.swift
@@ -30,10 +30,17 @@ private extension SecondaryNavigationTitleView {
     func initialSetup() {
         addSubview(avatarImageView)
         avatarImageView.translatesAutoresizingMaskIntoConstraints = false
-        avatarImageView.layer.cornerRadius = .barButtonItemDimension / 2
         avatarImageView.contentMode = .scaleAspectFill
         avatarImageView.clipsToBounds = true
-
+        
+        // Apply displayAvatarShape to avatarImageView
+        switch viewModel.identityContext.appPreferences.displayAvatarShape {
+            case .circle:
+                avatarImageView.layer.cornerRadius = .barButtonItemDimension / 2
+            case .roundedRectangle:
+                avatarImageView.layer.cornerRadius = .barButtonItemDimension / 8
+        }
+        
         addSubview(stackView)
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical


### PR DESCRIPTION
Summary

Addressing issue https://github.com/bdube/metatext/issues/78
Adding a user preference option Picker to allow users to choose between enclosing their avatars in a circle or a rounded rectangle.

#78 

Display effect:
![image](https://github.com/bdube/metatext/assets/32321396/a17907e8-6e62-4b29-abbe-b8723d41235a)
