### PR TITLE
Notifications fail to decode

### DIFF
--- a/Notification Service Extension/Notification Service Extension.entitlements
+++ b/Notification Service Extension/Notification Service Extension.entitlements
@@ -12,7 +12,7 @@
 	<true/>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.metabolist.metatext</string>
+		<string>$(AppIdentifierPrefix)com.gotgoat.metatext</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Notifications from the development APNs endpoint fail to decode. There is a mismatch in the notification extension entitlement that appears to be the cause, or at least part of the cause.

Fixes #93
