### PR TITLE
Don't load entire video files into memory when uploading attachments

### DIFF
--- a/HTTP/Sources/HTTP/SegmentedInputStream.swift
+++ b/HTTP/Sources/HTTP/SegmentedInputStream.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+class SegmentedInputStream : InputStream {
+  private let segments: [InputStream]
+  private var currentSegment = 0
+  private var _streamError: Error?
+  private var _streamStatus: Status
+
+  init(segments: [InputStream]) {
+    self.segments = segments
+    _streamStatus = .notOpen
+    super.init(data: Data())
+  }
+
+  override var streamError: Error? {
+    get { _streamError }
+  }
+
+  override var streamStatus: Status {
+    get { _streamStatus }
+  }
+
+  override func open() {
+    _streamStatus = .open
+  }
+
+  override func close() {
+    _streamStatus = .closed
+  }
+
+  override var delegate: StreamDelegate? {
+    get {
+      nil
+    }
+    set {
+    }
+  }
+
+  override func schedule(in aRunLoop: RunLoop, forMode mode: RunLoop.Mode) {
+  }
+
+  override func remove(from aRunLoop: RunLoop, forMode mode: RunLoop.Mode) {
+  }
+
+  override func property(forKey key: PropertyKey) -> Any? {
+    nil
+  }
+
+  override func read(_ buffer: UnsafeMutablePointer<UInt8>, maxLength len: Int) -> Int {
+    if !hasBytesAvailable {
+      return 0
+    }
+
+    var bytesRead = 0
+
+    while bytesRead < len {
+      let segment = segments[currentSegment]
+
+      if segment.streamStatus == .notOpen {
+        segment.open()
+      }
+
+      let readCount = segment.read(buffer + bytesRead, maxLength: len - bytesRead)
+      if readCount == -1 {
+        _streamError = segment.streamError
+        _streamStatus = .error
+        return -1
+      }
+      if readCount == 0 {
+        currentSegment += 1
+        if (currentSegment == segments.count) {
+          _streamStatus = .atEnd
+          return bytesRead
+        }
+      }
+
+      bytesRead += readCount
+    }
+    return bytesRead
+  }
+
+  override var hasBytesAvailable: Bool {
+    currentSegment < segments.count && (segments[currentSegment].streamStatus == .notOpen ||
+        segments[currentSegment].hasBytesAvailable)
+  }
+}

--- a/HTTP/Sources/HTTP/Target.swift
+++ b/HTTP/Sources/HTTP/Target.swift
@@ -38,14 +38,11 @@ public extension Target {
             urlRequest.setValue("application/json; charset=utf-8", forHTTPHeaderField: "Content-Type")
         } else if let multipartFormData = multipartFormData {
             let boundary = "Boundary-\(UUID().uuidString)"
-            var httpBody = Data()
 
-            for (key, value) in multipartFormData {
-                httpBody.append(value.httpBodyComponent(boundary: boundary, key: key))
-            }
+            var httpBodyStreams = multipartFormData.flatMap { key, value in value.httpBodyComponent(boundary: boundary, key: key) }
+            httpBodyStreams.append(InputStream(data: Data("--\(boundary)--".utf8)))
 
-            httpBody.append(Data("--\(boundary)--".utf8))
-            urlRequest.httpBody = httpBody
+            urlRequest.httpBodyStream = SegmentedInputStream(segments: httpBodyStreams)
             urlRequest.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
         }
 

--- a/MastodonAPI/Sources/MastodonAPI/Endpoints/AttachmentEndpoint.swift
+++ b/MastodonAPI/Sources/MastodonAPI/Endpoints/AttachmentEndpoint.swift
@@ -5,7 +5,7 @@ import HTTP
 import Mastodon
 
 public enum AttachmentEndpoint {
-    case create(data: Data, mimeType: String, description: String?, focus: Attachment.Meta.Focus?)
+    case create(inputStream: InputStream, mimeType: String, description: String?, focus: Attachment.Meta.Focus?)
     case update(id: Attachment.Id, description: String?, focus: Attachment.Meta.Focus?)
 }
 
@@ -27,10 +27,10 @@ extension AttachmentEndpoint: Endpoint {
 
     public var multipartFormData: [String: MultipartFormValue]? {
         switch self {
-        case let .create(data, mimeType, description, focus):
+        case let .create(inputStream, mimeType, description, focus):
             var params = [String: MultipartFormValue]()
 
-            params["file"] = .data(data, filename: UUID().uuidString, mimeType: mimeType)
+            params["file"] = .inputStream(inputStream, filename: UUID().uuidString, mimeType: mimeType)
 
             if let description = description {
                 params["description"] = .string(description)

--- a/ServiceLayer/Sources/ServiceLayer/Services/IdentityService.swift
+++ b/ServiceLayer/Sources/ServiceLayer/Services/IdentityService.swift
@@ -344,14 +344,14 @@ public extension IdentityService {
     }
 
     func uploadAttachment(
-        data: Data,
+        inputStream: InputStream,
         mimeType: String,
         description: String?,
         progress: Progress
     ) -> AnyPublisher<Attachment, Error> {
         mastodonAPIClient.request(
             AttachmentEndpoint.create(
-                data: data,
+                inputStream: inputStream,
                 mimeType: mimeType,
                 description: description,
                 focus: nil

--- a/ViewModels/Sources/ViewModels/Entities/AttachmentUpload.swift
+++ b/ViewModels/Sources/ViewModels/Entities/AttachmentUpload.swift
@@ -10,13 +10,13 @@ public class AttachmentUploadViewModel: ObservableObject {
     public let progress = Progress(totalUnitCount: 1)
     public let parentViewModel: ComposeStatusViewModel
 
-    let data: Data
+    let inputStream: InputStream
     let mimeType: String
     let description: String?
     var cancellable: AnyCancellable?
 
-    init(data: Data, mimeType: String, description: String?, parentViewModel: ComposeStatusViewModel) {
-        self.data = data
+    init(inputStream: InputStream, mimeType: String, description: String?, parentViewModel: ComposeStatusViewModel) {
+        self.inputStream = inputStream
         self.mimeType = mimeType
         self.description = description
         self.parentViewModel = parentViewModel
@@ -28,7 +28,7 @@ public extension AttachmentUploadViewModel {
 
     func upload() -> AnyPublisher<Attachment, Error> {
         parentViewModel.identityContext.service.uploadAttachment(
-            data: data,
+            inputStream: inputStream,
             mimeType: mimeType,
             description: description,
             progress: progress

--- a/ViewModels/Sources/ViewModels/View Models/CompositionViewModel.swift
+++ b/ViewModels/Sources/ViewModels/View Models/CompositionViewModel.swift
@@ -239,7 +239,7 @@ public extension CompositionViewModel {
                 .assignErrorsToAlertItem(to: \.alertItem, on: parentViewModel)
                 .map { result, description in
                     AttachmentUploadViewModel(
-                        data: result.data,
+                        inputStream: result.data,
                         mimeType: result.mimeType,
                         description: description,
                         parentViewModel: parentViewModel


### PR DESCRIPTION
### Summary

Currently, on upload the attachments are loaded into memory (and then copied a couple of times), which makes it impossible to upload video files larger than a few hundred megabytes. With this change, the video files are read using an `InputStream`, so the file is read from the storage as needed.

### Other Information

- [ ] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
- [x] The proposed changes are limited in scope to fixing bugs, or I have discussed larger scope changes via email
