### PR TITLE
Update fedi account in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Feditext is based on the [Metatext](https://github.com/metabolist/metatext) proj
 
 ## Testers Wanted
 
-If you are interested in joining the TestFlight group, please DM our official Fedi account [@Feditext@fedi.software](https://fedi.software/@Feditext), and follow it for announcements and release notes.
+If you are interested in joining the TestFlight group, please DM our official Fedi account [@Feditext@mastodon.social](https://mastodon.social/@Feditext), and follow it for announcements and release notes.
 
 ## Contributing Bug Reports
 


### PR DESCRIPTION
### Summary

the fedi account mention in the readme is outdated, i just updated it to the mastodon.social account

- [x] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
- [x] The proposed changes are limited in scope to fixing bugs, or I have discussed larger scope changes via email
