### PR TITLE
fix GoToSocial capitalization

### DIFF
--- a/Localizations/en.lproj/Localizable.strings
+++ b/Localizations/en.lproj/Localizable.strings
@@ -198,7 +198,7 @@
 "flavor.hometown.name" = "Hometown";
 "flavor.pleroma.name" = "Pleroma";
 "flavor.akkoma.name" = "Akkoma";
-"flavor.gotosocial.name" = "GotoSocial";
+"flavor.gotosocial.name" = "GoToSocial";
 "flavor.calckey.name" = "Calckey";
 "flavor.firefish.name" = "Firefish";
 "followed-tags.new-tag-title" = "Hashtag (without #)";

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Feditext
 
-A free, open-source iOS client for [Mastodon](https://joinmastodon.org/), [Glitch](https://glitch-soc.github.io/docs/), [GotoSocial](https://gotosocial.org/), [Firefish](https://joinfirefish.org/), [Akkoma](https://akkoma.social/), and other Mastodon-API-compatible Fediverse instance servers.
+A free, open-source iOS client for [Mastodon](https://joinmastodon.org/), [Glitch](https://glitch-soc.github.io/docs/), [GoToSocial](https://gotosocial.org/), [Firefish](https://joinfirefish.org/), [Akkoma](https://akkoma.social/), and other Mastodon-API-compatible Fediverse instance servers.
 
 Feditext is based on the [Metatext](https://github.com/metabolist/metatext) project, which has concluded and is no longer maintained. Feditext is updated with Mastodon 4 features and better support for non-Mastodon instances.
 


### PR DESCRIPTION
just to fix the capitalization of the "GoToSocial" word, accordingly to its website: https://gotosocial.org/

- [x] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
- [x] The proposed changes are limited in scope to fixing bugs, or I have discussed larger scope changes via email
