### PR TITLE
Suppress SwiftLint warnings on TODO comments

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,3 +10,6 @@ file_length:
   warning: 500
   error: 1000
   ignore_comment_only_lines: true
+
+todo:
+  only: FIXME


### PR DESCRIPTION
### Summary

As mentioned in issue #2 suppress the SwiftLint warnings on TODO comments, as they are longer-term markers indicating ideas for future work.

- [x] I have signed [Metabolist's Contributor License Agreement](https://metabolist.org/cla)
- [x] The proposed changes are limited in scope to fixing bugs, or I have discussed larger scope changes via email
